### PR TITLE
security: Sanitize logs with Google API Errors when wrapped

### DIFF
--- a/modules/google/cloud/cloud.go
+++ b/modules/google/cloud/cloud.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/googleapi"
 	googleoauth2 "google.golang.org/api/oauth2/v2"
 )
 
@@ -25,10 +27,60 @@ func tokenInfoEmail(ctx context.Context, creds *google.Credentials) (string, err
 	tokenInfoCall := oauth2Service.Tokeninfo().AccessToken(token.AccessToken)
 	tokenInfo, err := tokenInfoCall.Do()
 	if err != nil {
-		return "", err
+		return "", sanitizeGoogleAPIError("tokeninfo", err)
 	}
 
 	return tokenInfo.Email, nil
+}
+
+// sanitizeGoogleAPIError removes any potentially sensitive token material from Google API errors
+// returned by Google API calls. Some return request information with sensitive data like tokens
+// when using error wrapping.
+func sanitizeGoogleAPIError(apiName string, err error) error {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		if desc := extractGoogleAPIErrorDescription(apiErr.Body); desc != "" {
+			return fmt.Errorf("%s request failed: %s", apiName, desc)
+		}
+		if apiErr.Code > 0 {
+			return fmt.Errorf("%s request failed with status %d", apiName, apiErr.Code)
+		}
+		return fmt.Errorf("%s request failed", apiName)
+	}
+	return fmt.Errorf("unknown error while calling %s endpoint", apiName)
+}
+
+// extractGoogleAPIErrorDescription parses a Google API error body and returns a safe human
+// readable description when available.
+func extractGoogleAPIErrorDescription(body string) string {
+	if strings.TrimSpace(body) == "" {
+		return ""
+	}
+	var payload struct {
+		ErrorDescription string `json:"error_description"`
+		Error            any    `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return ""
+	}
+	if strings.TrimSpace(payload.ErrorDescription) != "" {
+		return strings.TrimSpace(payload.ErrorDescription)
+	}
+	switch e := payload.Error.(type) {
+	case string:
+		return strings.TrimSpace(e)
+	case map[string]any:
+		if desc, ok := e["error_description"].(string); ok {
+			return strings.TrimSpace(desc)
+		}
+		if msg, ok := e["message"].(string); ok {
+			return strings.TrimSpace(msg)
+		}
+		if status, ok := e["status"].(string); ok {
+			return strings.TrimSpace(status)
+		}
+	}
+	return ""
 }
 
 // DefaultCredentials returns the default Google Cloud credentials. It supports ADC (Application

--- a/modules/google/cloud/cloud_test.go
+++ b/modules/google/cloud/cloud_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/googleapi"
 )
 
 func testCredentialsTypeFromJSON(t *testing.T, credJSON string) google.CredentialsType {
@@ -194,4 +195,49 @@ func TestIamUser_EmptyJSONFallsBackToTokenInspection(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, "wi-principal@example.com", got)
+}
+
+func TestSanitizeGoogleAPIError_UsesErrorDescriptionFromBody(t *testing.T) {
+	err := sanitizeGoogleAPIError(
+		"token info",
+		&googleapi.Error{
+			Code:    400,
+			Message: "Bad Request",
+			Body:    `{"error_description":"Invalid Value"}`,
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid Value")
+	require.NotContains(t, err.Error(), "access_token=")
+	require.NotContains(t, err.Error(), "https://")
+}
+
+func TestSanitizeGoogleAPIError_GenericFallbackDoesNotExposeWrappedError(t *testing.T) {
+	err := sanitizeGoogleAPIError(
+		"id token",
+		errors.New(`Post "https://www.googleapis.com/oauth2/v2/tokeninfo?access_token=secret-token&foo=bar": context deadline exceeded`),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown error while calling id token endpoint")
+	require.NotContains(t, err.Error(), "secret-token")
+	require.NotContains(t, err.Error(), "https://www.googleapis.com/oauth2/v2/tokeninfo")
+
+	err = sanitizeGoogleAPIError(
+		"id token",
+		errors.New(`Get "https://oauth2.googleapis.com/tokeninfo?id_token=secret-id-token": unauthorized`),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown error while calling id token endpoint")
+	require.NotContains(t, err.Error(), "secret-id-token")
+	require.NotContains(t, err.Error(), "https://oauth2.googleapis.com/tokeninfo")
+}
+
+func TestExtractGoogleAPIErrorDescription_OptionalFields(t *testing.T) {
+	require.Equal(t, "", extractGoogleAPIErrorDescription(`{}`))
+	require.Equal(t, "", extractGoogleAPIErrorDescription(`{"foo":"bar"}`))
+	require.Equal(
+		t,
+		"nested-invalid",
+		extractGoogleAPIErrorDescription(`{"error":{"error_description":"nested-invalid"}}`),
+	)
 }


### PR DESCRIPTION
When a [googleapi.Error](https://pkg.go.dev/google.golang.org/api/googleapi#Error) is returned and "wrapped" into a response it can sometimes contain access tokens or other somewhat sensitive data.