### PR TITLE
fix: Add Closer interface for Modules to cleanup resources after workflow run

### DIFF
--- a/docs/developer-guide/modules.md
+++ b/docs/developer-guide/modules.md
@@ -90,3 +90,13 @@ The `Set` method is called when the resource is not in the desired state. When r
 may need to not simply create a resource, but inspect it and change it to the desired state. After
 configuring the resource, the `Set` method must set all outputs in the provided
 [`ModuleContext`](types.md#modulecontext) that are expected to be returned by the module.
+
+## Cleanup
+
+Some modules allocate resources that should be released after a workflow run completes (for example
+open clients, pooled connections, or temporary handles that are not exposed as outputs). Each
+module must implement [`io.Closer`](https://pkg.go.dev/io#Closer) if it creates resources that need 
+to be closed when the workflow is completed.
+
+When implemented, `Close()` is called by the workflow runtime at the end of the run, including
+when the run fails.

--- a/modules/google/cloudsql/managed_instance.go
+++ b/modules/google/cloudsql/managed_instance.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"slices"
 	"strings"
@@ -23,6 +24,7 @@ func init() {
 }
 
 var _ blackstart.Module = &managedInstance{}
+var _ io.Closer = &managedInstance{}
 var requiredCloudSqlManagedInstanceParameters = []string{inputInstance}
 
 const checkCloudSqlSuperuserRoleQuery = `
@@ -38,9 +40,10 @@ func NewCloudSqlManagedInstance() blackstart.Module {
 }
 
 type managedInstance struct {
-	target     *connectionConfig
-	sqlService *sqladmin.Service
-	creds      *google.Credentials
+	target             *connectionConfig
+	sqlService         *sqladmin.Service
+	creds              *google.Credentials
+	managedConnections []*sql.DB
 }
 
 func (m *managedInstance) Info() blackstart.ModuleInfo {
@@ -226,6 +229,12 @@ func (m *managedInstance) Check(ctx blackstart.ModuleContext) (bool, error) {
 		}
 		return false, fmt.Errorf("failed to open database connection: %w", err)
 	}
+	keepConnectionOpen := false
+	defer func() {
+		if !keepConnectionOpen {
+			_ = db.Close()
+		}
+	}()
 
 	isAdmin, err := checkIfSuperuser(ctx, db)
 	if err != nil {
@@ -244,6 +253,8 @@ func (m *managedInstance) Check(ctx blackstart.ModuleContext) (bool, error) {
 		if err != nil {
 			return res, err
 		}
+		m.trackManagedConnection(db)
+		keepConnectionOpen = true
 	}
 	return res, nil
 }
@@ -326,12 +337,44 @@ func (m *managedInstance) Set(ctx blackstart.ModuleContext) error {
 	if err != nil {
 		return fmt.Errorf("failed to open database connection: %w", err)
 	}
+	keepConnectionOpen := false
+	defer func() {
+		if !keepConnectionOpen {
+			_ = db.Close()
+		}
+	}()
 	err = ctx.Output(outputConnection, db)
 	if err != nil {
 		return err
 	}
+	m.trackManagedConnection(db)
+	keepConnectionOpen = true
 
 	return err
+}
+
+// Close releases any managed database connections.
+func (m *managedInstance) Close() error {
+	var closeErr error
+	for _, db := range m.managedConnections {
+		if db == nil {
+			continue
+		}
+		if err := db.Close(); err != nil {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	m.managedConnections = nil
+	return closeErr
+}
+
+// trackManagedConnection registers a connection for lifecycle cleanup at the
+// end of workflow execution.
+func (m *managedInstance) trackManagedConnection(db *sql.DB) {
+	if db == nil {
+		return
+	}
+	m.managedConnections = append(m.managedConnections, db)
 }
 
 // setup initializes the module by reading inputs, creating the target configuration and setting

--- a/modules/postgres/connection.go
+++ b/modules/postgres/connection.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/lib/pq"
@@ -12,6 +13,8 @@ import (
 )
 
 var requiredConnectionParameters = []string{inputUsername}
+var _ blackstart.Module = &connectionModule{}
+var _ io.Closer = &connectionModule{}
 
 func init() {
 	blackstart.RegisterModule("postgres_connection", NewPostgresConnection)
@@ -154,7 +157,22 @@ func (c *connectionModule) Set(ctx blackstart.ModuleContext) error {
 		return fmt.Errorf("error pinging database: %w", err)
 	}
 	c.db = db
+	if err = ctx.Output(outputConnection, c.db); err != nil {
+		_ = c.db.Close()
+		c.db = nil
+		return err
+	}
 	return nil
+}
+
+// Close releases the active database connection held by the module.
+func (c *connectionModule) Close() error {
+	if c.db == nil {
+		return nil
+	}
+	err := c.db.Close()
+	c.db = nil
+	return err
 }
 
 // createTargetConnection creates the target connection from the module context inputs.

--- a/modules/postgres/connection_test.go
+++ b/modules/postgres/connection_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"net/url"
 	"strconv"
 	"strings"
@@ -13,6 +14,19 @@ import (
 
 	"github.com/pezops/blackstart"
 )
+
+type capturingModuleContext struct {
+	blackstart.ModuleContext
+	outputs map[string]interface{}
+}
+
+func (c *capturingModuleContext) Output(key string, value interface{}) error {
+	if c.outputs == nil {
+		c.outputs = map[string]interface{}{}
+	}
+	c.outputs[key] = value
+	return c.ModuleContext.Output(key, value)
+}
 
 func TestConnectionValidate(t *testing.T) {
 	mod := connectionModule{}
@@ -139,4 +153,97 @@ func TestConnectionSet(t *testing.T) {
 	// Verify the connection is usable
 	err = mod.db.Ping()
 	require.NoError(t, err)
+}
+
+func TestConnectionSet_EmitsConnectionOutput(t *testing.T) {
+	pctx := context.Background()
+
+	dsn, err := testPg.ConnectionString(pctx)
+	require.NoError(t, err)
+
+	parse, err := url.Parse(dsn)
+	require.NoError(t, err)
+
+	pgHost := strings.Split(parse.Host, ":")[0]
+	pgPort, err := strconv.Atoi(parse.Port())
+	require.NoError(t, err)
+	pgUsername := parse.User.Username()
+	pgPassword, _ := parse.User.Password()
+	pgDatabase := strings.TrimPrefix(parse.Path, "/")
+
+	mod := connectionModule{}
+	op := &blackstart.Operation{
+		Id:     "test",
+		Module: "postgres_connection",
+		Name:   "Test PostgreSQL connection",
+		Inputs: map[string]blackstart.Input{
+			inputHost:     blackstart.NewInputFromValue(pgHost),
+			inputPort:     blackstart.NewInputFromValue(pgPort),
+			inputDatabase: blackstart.NewInputFromValue(pgDatabase),
+			inputUsername: blackstart.NewInputFromValue(pgUsername),
+			inputPassword: blackstart.NewInputFromValue(pgPassword),
+			inputSslMode:  blackstart.NewInputFromValue("disable"),
+		},
+	}
+	require.NoError(t, mod.Validate(*op))
+
+	baseCtx := blackstart.OpContext(blackstart.InputsToContext(pctx, op.Inputs), op)
+	ctx := &capturingModuleContext{ModuleContext: baseCtx}
+
+	check, err := mod.Check(ctx)
+	require.NoError(t, err)
+	require.False(t, check)
+
+	err = mod.Set(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, mod.db)
+
+	value, ok := ctx.outputs[outputConnection]
+	require.True(t, ok)
+	outDb, ok := value.(*sql.DB)
+	require.True(t, ok)
+	require.Equal(t, mod.db, outDb)
+}
+
+func TestConnectionClose_ClosesConnection(t *testing.T) {
+	pctx := context.Background()
+
+	dsn, err := testPg.ConnectionString(pctx)
+	require.NoError(t, err)
+
+	parse, err := url.Parse(dsn)
+	require.NoError(t, err)
+
+	pgHost := strings.Split(parse.Host, ":")[0]
+	pgPort, err := strconv.Atoi(parse.Port())
+	require.NoError(t, err)
+	pgUsername := parse.User.Username()
+	pgPassword, _ := parse.User.Password()
+	pgDatabase := strings.TrimPrefix(parse.Path, "/")
+
+	mod := connectionModule{}
+	op := &blackstart.Operation{
+		Id:     "test",
+		Module: "postgres_connection",
+		Name:   "Test PostgreSQL connection",
+		Inputs: map[string]blackstart.Input{
+			inputHost:     blackstart.NewInputFromValue(pgHost),
+			inputPort:     blackstart.NewInputFromValue(pgPort),
+			inputDatabase: blackstart.NewInputFromValue(pgDatabase),
+			inputUsername: blackstart.NewInputFromValue(pgUsername),
+			inputPassword: blackstart.NewInputFromValue(pgPassword),
+			inputSslMode:  blackstart.NewInputFromValue("disable"),
+		},
+	}
+	require.NoError(t, mod.Validate(*op))
+
+	ctx := blackstart.OpContext(blackstart.InputsToContext(pctx, op.Inputs), op)
+	check, err := mod.Check(ctx)
+	require.NoError(t, err)
+	require.False(t, check)
+	require.NoError(t, mod.Set(ctx))
+	require.NotNil(t, mod.db)
+
+	require.NoError(t, mod.Close())
+	require.Nil(t, mod.db)
 }

--- a/operation.go
+++ b/operation.go
@@ -65,13 +65,19 @@ func (o *Operation) setup() error {
 func (o *Operation) execute(mctx ModuleContext, logger *slog.Logger) error {
 	var m Module
 	var err error
-	var check bool
 
 	logger.Debug("instantiating module for operation", "module", o.Module, "id", o.Id)
 	m, err = NewModule(o)
 	if err != nil {
 		return err
 	}
+
+	return o.executeWithModule(m, mctx, logger)
+}
+
+func (o *Operation) executeWithModule(m Module, mctx ModuleContext, logger *slog.Logger) error {
+	var err error
+	var check bool
 
 	logger.Info("operation check", "module", o.Module, "id", o.Id)
 	check, err = m.Check(mctx)

--- a/workflow.go
+++ b/workflow.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"reflect"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -99,6 +102,18 @@ func (we *workflowExecution) execute(ctx context.Context) WorkflowResult {
 
 	// Create all modules and validate the operations.
 	modules := make(map[string]Module)
+	defer func() {
+		closeErr := closeWorkflowModules(modules)
+		if closeErr == nil {
+			return
+		}
+		if result.Err == nil {
+			result.Err = closeErr
+			return
+		}
+		result.Err = fmt.Errorf("%w; %v", result.Err, closeErr)
+	}()
+
 	operations := make(map[string]*Operation)
 	moduleInfo := make(map[string]ModuleInfo)
 
@@ -174,7 +189,12 @@ func (we *workflowExecution) execute(ctx context.Context) WorkflowResult {
 		}
 
 		operationContexts[id] = mctx
-		err = op.execute(mctx, we.logger)
+		m, ok := modules[op.Id]
+		if !ok {
+			result.Err = fmt.Errorf("unable to find module for operation '%s'", op.Id)
+			return result
+		}
+		err = op.executeWithModule(m, mctx, we.logger)
 		if err != nil {
 			result.Err = err
 			return result
@@ -183,6 +203,32 @@ func (we *workflowExecution) execute(ctx context.Context) WorkflowResult {
 	}
 
 	return result
+}
+
+func closeWorkflowModules(modules map[string]Module) error {
+	if len(modules) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(modules))
+	for id := range modules {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	errs := make([]string, 0)
+	for _, id := range ids {
+		closer, ok := modules[id].(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := closer.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("operation %q: %v", id, err))
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("module cleanup failed: %s", strings.Join(errs, "; "))
 }
 
 // findDuplicateOperationID returns the first duplicate operation ID and the corresponding

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -4,11 +4,52 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var cleanupModuleCloseCalls atomic.Int32
+
+type cleanupTestModule struct{}
+
+func init() {
+	RegisterModule("cleanup_test_module", func() Module { return &cleanupTestModule{} })
+}
+
+func (m *cleanupTestModule) Info() ModuleInfo {
+	return ModuleInfo{
+		Id: "cleanup_test_module",
+		Inputs: map[string]InputValue{
+			testCheckResult: {
+				Type:     reflect.TypeFor[bool](),
+				Required: true,
+			},
+			testSetResult: {
+				Type:     reflect.TypeFor[bool](),
+				Required: true,
+			},
+		},
+		Outputs: map[string]OutputValue{},
+	}
+}
+
+func (m *cleanupTestModule) Validate(_ Operation) error { return nil }
+func (m *cleanupTestModule) Check(ctx ModuleContext) (bool, error) {
+	return InputAs[bool](ctxMustInput(ctx, testCheckResult), true)
+}
+func (m *cleanupTestModule) Set(_ ModuleContext) error { return nil }
+func (m *cleanupTestModule) Close() error {
+	cleanupModuleCloseCalls.Add(1)
+	return nil
+}
+
+func ctxMustInput(ctx ModuleContext, key string) Input {
+	in, _ := ctx.Input(key)
+	return in
+}
 
 type testOpValues map[string]map[string]interface{}
 
@@ -285,6 +326,27 @@ func TestWorkflowExecution_DuplicateOperationID(t *testing.T) {
 	require.NotNil(t, res.Op)
 	require.Equal(t, "dup", res.Op.Id)
 	require.Equal(t, phaseSetup, res.Phase)
+}
+
+func TestWorkflowExecution_CallsOptionalModuleClose(t *testing.T) {
+	cleanupModuleCloseCalls.Store(0)
+	wf := Workflow{
+		Name: "cleanup-close-test",
+		Operations: []Operation{
+			{
+				Id:     "cleanup-op",
+				Module: "cleanup_test_module",
+				Inputs: map[string]Input{
+					testCheckResult: NewInputFromValue(true),
+					testSetResult:   NewInputFromValue(true),
+				},
+			},
+		},
+	}
+
+	res := wf.Run(context.Background())
+	require.NoError(t, res.Err)
+	require.Equal(t, int32(1), cleanupModuleCloseCalls.Load())
 }
 
 // TestOpoSort tests the topological sorting of operations into an expected order.


### PR DESCRIPTION
This adds a new Closer interface support for Modules and implements it on `postgres_connection` and `google_cloudsql_managed_instance`. Without a Closer interface