### PR TITLE
fix: Ignore unsupported Postgres privileges on older versions of Postgres

### DIFF
--- a/modules/postgres/grant.go
+++ b/modules/postgres/grant.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/lib/pq"
+
 	"github.com/pezops/blackstart"
 	"github.com/pezops/blackstart/util"
 )
@@ -949,15 +951,27 @@ func (g *grantModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 	}
 
 	for _, target := range targets {
-		query, queryParams, queryErr := getGrantExistsQuery(target)
+		existsQueries, queryErr := getGrantExistsQueries(target)
 		if queryErr != nil {
 			return false, fmt.Errorf("error getting grant query: %w", queryErr)
 		}
 
-		var exists bool
-		err = g.db.QueryRowContext(ctx, query, queryParams...).Scan(&exists)
-		if err != nil {
-			return false, fmt.Errorf("error checking grant: %w", err)
+		exists := true
+		for _, existsQuery := range existsQueries {
+			var queryExists bool
+			err = g.db.QueryRowContext(ctx, existsQuery.query, existsQuery.params...).Scan(&queryExists)
+			if err != nil {
+				if isPQInvalidParameterValueError(err) {
+					// Ignore unsupported privilege checks (for example, newer privileges on
+					// older server versions) and continue evaluating remaining checks.
+					continue
+				}
+				return false, fmt.Errorf("error checking grant: %w", err)
+			}
+			if !queryExists {
+				exists = false
+				break
+			}
 		}
 
 		if ctx.DoesNotExist() {
@@ -972,6 +986,85 @@ func (g *grantModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// isPQInvalidParameterValueError returns true for PostgreSQL SQLSTATE 22023.
+func isPQInvalidParameterValueError(err error) bool {
+	var pqErr *pq.Error
+	if !errors.As(err, &pqErr) {
+		return false
+	}
+	return string(pqErr.Code) == "22023"
+}
+
+type grantExistsQuery struct {
+	query  string
+	params []interface{}
+}
+
+// getGrantExistsQueries returns one or more check queries for a grant target.
+// For ALL permissions, it expands to per-permission checks.
+func getGrantExistsQueries(target *grant) ([]grantExistsQuery, error) {
+	grantScope, err := stringToScope(target.Scope)
+	if err != nil {
+		return nil, err
+	}
+	normalizedPermission := normalizeGrantPermissionToken(grantScope, target.Permission)
+	if normalizedPermission != "ALL" {
+		q, p, queryErr := getGrantExistsQuery(target)
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		return []grantExistsQuery{{query: q, params: p}}, nil
+	}
+
+	allPermissions := grantAllPermissions(grantScope)
+	if len(allPermissions) == 0 {
+		// Defensive fallback; INSTANCE scope with ALL is already invalid upstream.
+		q, p, queryErr := getGrantExistsQuery(target)
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		return []grantExistsQuery{{query: q, params: p}}, nil
+	}
+
+	queries := make([]grantExistsQuery, 0, len(allPermissions))
+	for _, permission := range allPermissions {
+		specific := *target
+		specific.Permission = permission
+		q, p, queryErr := getGrantExistsQuery(&specific)
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		queries = append(queries, grantExistsQuery{query: q, params: p})
+	}
+	return queries, nil
+}
+
+// grantAllPermissions expands ALL for each scope into concrete permissions.
+func grantAllPermissions(grantScope scope) []string {
+	switch grantScope {
+	case scopes.database:
+		return []string{"CREATE", "CONNECT", "TEMPORARY"}
+	case scopes.schema:
+		return []string{"CREATE", "USAGE"}
+	case scopes.table:
+		return []string{"SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER", "MAINTAIN"}
+	case scopes.sequence:
+		return []string{"USAGE", "SELECT", "UPDATE"}
+	case scopes.function, scopes.procedure, scopes.routine:
+		return []string{"EXECUTE"}
+	case scopes.domain, scopes.fdw, scopes.foreignServer, scopes.language, scopes.typ:
+		return []string{"USAGE"}
+	case scopes.largeObject:
+		return []string{"SELECT", "UPDATE"}
+	case scopes.parameter:
+		return []string{"SET", "ALTER SYSTEM"}
+	case scopes.tablespace:
+		return []string{"CREATE"}
+	default:
+		return nil
+	}
 }
 
 func (g *grantModule) Set(ctx blackstart.ModuleContext) error {

--- a/modules/postgres/grant_test.go
+++ b/modules/postgres/grant_test.go
@@ -8,11 +8,38 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lib/pq"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pezops/blackstart"
 )
+
+func TestIsPQInvalidParameterValueError(t *testing.T) {
+	t.Run("matches_pq_22023", func(t *testing.T) {
+		err := &pq.Error{
+			Code:    "22023",
+			Message: `unrecognized privilege type: "MAINTAIN"`,
+		}
+		require.True(t, isPQInvalidParameterValueError(err))
+	})
+
+	t.Run("matches_pq_22023_with_other_messages", func(t *testing.T) {
+		err := &pq.Error{
+			Code:    "22023",
+			Message: "invalid parameter value",
+		}
+		require.True(t, isPQInvalidParameterValueError(err))
+	})
+
+	t.Run("ignores_other_error_codes", func(t *testing.T) {
+		err := &pq.Error{
+			Code:    "42501",
+			Message: `unrecognized privilege type: "MAINTAIN"`,
+		}
+		require.False(t, isPQInvalidParameterValueError(err))
+	})
+}
 
 func TestGrantValidate_StaticPermissionValidation(t *testing.T) {
 	m := grantModule{}
@@ -323,6 +350,28 @@ func TestGrant(t *testing.T) {
 				inputPermission: blackstart.NewInputFromValue([]string{"SELECT", "UPDATE"}),
 				inputSchema:     blackstart.NewInputFromValue("public"),
 				inputResource:   blackstart.NewInputFromValue("blackstart_grant_test_orders"),
+				inputScope:      blackstart.NewInputFromValue("table"),
+				inputConnection: blackstart.NewInputFromValue(db),
+			},
+			grant: grantModule{},
+		},
+		{
+			name: "table_all_grant",
+			setup: func(t *testing.T) {
+				_, err = db.Exec("CREATE ROLE blackstart_2_all")
+				if err != nil {
+					t.Fatalf("failed to create Role: %v", err)
+				}
+				_, err = db.Exec("CREATE TABLE IF NOT EXISTS public.blackstart_grant_test_all_table (id INT)")
+				if err != nil {
+					t.Fatalf("failed to create table: %v", err)
+				}
+			},
+			inputs: map[string]blackstart.Input{
+				inputRole:       blackstart.NewInputFromValue("blackstart_2_all"),
+				inputPermission: blackstart.NewInputFromValue("ALL"),
+				inputSchema:     blackstart.NewInputFromValue("public"),
+				inputResource:   blackstart.NewInputFromValue("blackstart_grant_test_all_table"),
 				inputScope:      blackstart.NewInputFromValue("table"),
 				inputConnection: blackstart.NewInputFromValue(db),
 			},

--- a/modules/postgres/queries.go
+++ b/modules/postgres/queries.go
@@ -189,32 +189,32 @@ JOIN pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname = $2
   AND p.prokind IN ('f', 'p');
 `
-	getGrantDomainQuery = `SELECT has_type_privilege($1, $2, $3);`
-	getGrantDomainAllQuery = `SELECT has_type_privilege($1, $2, $3);`
-	getGrantFdwQuery = `SELECT has_foreign_data_wrapper_privilege($1, $2, $3);`
-	getGrantFdwAllQuery = `SELECT has_foreign_data_wrapper_privilege($1, $2, $3);`
-	getGrantForeignServerQuery = `SELECT has_server_privilege($1, $2, $3);`
+	getGrantDomainQuery           = `SELECT has_type_privilege($1, $2, $3);`
+	getGrantDomainAllQuery        = `SELECT has_type_privilege($1, $2, $3);`
+	getGrantFdwQuery              = `SELECT has_foreign_data_wrapper_privilege($1, $2, $3);`
+	getGrantFdwAllQuery           = `SELECT has_foreign_data_wrapper_privilege($1, $2, $3);`
+	getGrantForeignServerQuery    = `SELECT has_server_privilege($1, $2, $3);`
 	getGrantForeignServerAllQuery = `SELECT has_server_privilege($1, $2, $3);`
-	getGrantLanguageQuery = `SELECT has_language_privilege($1, $2, $3);`
-	getGrantLanguageAllQuery = `SELECT has_language_privilege($1, $2, $3);`
-	getGrantLargeObjectQuery = `SELECT has_largeobject_privilege($1, $2::oid, $3);`
-	getGrantLargeObjectAllQuery = `
+	getGrantLanguageQuery         = `SELECT has_language_privilege($1, $2, $3);`
+	getGrantLanguageAllQuery      = `SELECT has_language_privilege($1, $2, $3);`
+	getGrantLargeObjectQuery      = `SELECT has_largeobject_privilege($1, $2::oid, $3);`
+	getGrantLargeObjectAllQuery   = `
 SELECT (
   has_largeobject_privilege($1, $2::oid, $3)
   AND has_largeobject_privilege($1, $2::oid, $4)
 );
 `
-	getGrantParameterQuery = `SELECT has_parameter_privilege($1, $2, $3);`
+	getGrantParameterQuery    = `SELECT has_parameter_privilege($1, $2, $3);`
 	getGrantParameterAllQuery = `
 SELECT (
   has_parameter_privilege($1, $2, $3)
   AND has_parameter_privilege($1, $2, $4)
 );
 `
-	getGrantTablespaceQuery = `SELECT has_tablespace_privilege($1, $2, $3);`
-	getGrantTablespaceAllQuery = `SELECT has_tablespace_privilege($1, $2, $3);`
-	getGrantTypeQuery = `SELECT has_type_privilege($1, $2, $3);`
-	getGrantTypeAllQuery = `SELECT has_type_privilege($1, $2, $3);`
+	getGrantTablespaceQuery           = `SELECT has_tablespace_privilege($1, $2, $3);`
+	getGrantTablespaceAllQuery        = `SELECT has_tablespace_privilege($1, $2, $3);`
+	getGrantTypeQuery                 = `SELECT has_type_privilege($1, $2, $3);`
+	getGrantTypeAllQuery              = `SELECT has_type_privilege($1, $2, $3);`
 	getGrantAllTablesInSchemaAllQuery = `
 SELECT
   COALESCE(
@@ -248,51 +248,51 @@ SELECT EXISTS (
     AND r.rolcanlogin = $5 AND r.rolreplication = $6
 )
 `
-	setGrantInstanceTemplate  = `GRANT "{{.Permission}}" TO "{{.Role}}";`
-	setGrantDatabaseTemplate  = `GRANT {{.Permission}} ON DATABASE "{{.Resource}}" TO "{{.Role}}";`
-	setGrantSchemaTemplate    = `GRANT {{.Permission}} ON SCHEMA "{{.Resource}}" TO "{{.Role}}";`
-	setGrantTableTemplate     = `GRANT {{.Permission}} ON TABLE "{{.Schema}}"."{{.Resource}}" TO "{{.Role}}";`
-	setGrantAllTablesTemplate = `GRANT {{.Permission}} ON ALL TABLES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
-	setGrantSequenceTemplate  = `GRANT {{.Permission}} ON SEQUENCE "{{.Schema}}"."{{.Resource}}" TO "{{.Role}}";`
-	setGrantAllSequencesTemplate = `GRANT {{.Permission}} ON ALL SEQUENCES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
-	setGrantFunctionTemplate = `GRANT {{.Permission}} ON FUNCTION "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
-	setGrantAllFunctionsTemplate = `GRANT {{.Permission}} ON ALL FUNCTIONS IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
-	setGrantProcedureTemplate = `GRANT {{.Permission}} ON PROCEDURE "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
-	setGrantAllProceduresTemplate = `GRANT {{.Permission}} ON ALL PROCEDURES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
-	setGrantRoutineTemplate = `GRANT {{.Permission}} ON ROUTINE "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
-	setGrantAllRoutinesTemplate = `GRANT {{.Permission}} ON ALL ROUTINES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
-	setGrantDomainTemplate = `GRANT {{.Permission}} ON DOMAIN "{{.Resource}}" TO "{{.Role}}";`
-	setGrantFdwTemplate = `GRANT {{.Permission}} ON FOREIGN DATA WRAPPER "{{.Resource}}" TO "{{.Role}}";`
-	setGrantForeignServerTemplate = `GRANT {{.Permission}} ON FOREIGN SERVER "{{.Resource}}" TO "{{.Role}}";`
-	setGrantLanguageTemplate = `GRANT {{.Permission}} ON LANGUAGE "{{.Resource}}" TO "{{.Role}}";`
-	setGrantLargeObjectTemplate = `GRANT {{.Permission}} ON LARGE OBJECT {{.Resource}} TO "{{.Role}}";`
-	setGrantParameterTemplate = `GRANT {{.Permission}} ON PARAMETER "{{.Resource}}" TO "{{.Role}}";`
-	setGrantTablespaceTemplate = `GRANT {{.Permission}} ON TABLESPACE "{{.Resource}}" TO "{{.Role}}";`
-	setGrantTypeTemplate = `GRANT {{.Permission}} ON TYPE "{{.Resource}}" TO "{{.Role}}";`
-	setRevokeInstanceTemplate = `REVOKE "{{.Permission}}" FROM "{{.Role}}";`
-	setRevokeDatabaseTemplate = `REVOKE {{.Permission}} ON DATABASE "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeSchemaTemplate   = `REVOKE {{.Permission}} ON SCHEMA "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeTableTemplate    = `REVOKE {{.Permission}} ON TABLE "{{.Schema}}"."{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeAllTablesTemplate = `REVOKE {{.Permission}} ON ALL TABLES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
-	setRevokeSequenceTemplate = `REVOKE {{.Permission}} ON SEQUENCE "{{.Schema}}"."{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeAllSequencesTemplate = `REVOKE {{.Permission}} ON ALL SEQUENCES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
-	setRevokeFunctionTemplate = `REVOKE {{.Permission}} ON FUNCTION "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
-	setRevokeAllFunctionsTemplate = `REVOKE {{.Permission}} ON ALL FUNCTIONS IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
-	setRevokeProcedureTemplate = `REVOKE {{.Permission}} ON PROCEDURE "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
+	setGrantInstanceTemplate       = `GRANT "{{.Permission}}" TO "{{.Role}}";`
+	setGrantDatabaseTemplate       = `GRANT {{.Permission}} ON DATABASE "{{.Resource}}" TO "{{.Role}}";`
+	setGrantSchemaTemplate         = `GRANT {{.Permission}} ON SCHEMA "{{.Resource}}" TO "{{.Role}}";`
+	setGrantTableTemplate          = `GRANT {{.Permission}} ON TABLE "{{.Schema}}"."{{.Resource}}" TO "{{.Role}}";`
+	setGrantAllTablesTemplate      = `GRANT {{.Permission}} ON ALL TABLES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
+	setGrantSequenceTemplate       = `GRANT {{.Permission}} ON SEQUENCE "{{.Schema}}"."{{.Resource}}" TO "{{.Role}}";`
+	setGrantAllSequencesTemplate   = `GRANT {{.Permission}} ON ALL SEQUENCES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
+	setGrantFunctionTemplate       = `GRANT {{.Permission}} ON FUNCTION "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
+	setGrantAllFunctionsTemplate   = `GRANT {{.Permission}} ON ALL FUNCTIONS IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
+	setGrantProcedureTemplate      = `GRANT {{.Permission}} ON PROCEDURE "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
+	setGrantAllProceduresTemplate  = `GRANT {{.Permission}} ON ALL PROCEDURES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
+	setGrantRoutineTemplate        = `GRANT {{.Permission}} ON ROUTINE "{{.Schema}}".{{.Resource}} TO "{{.Role}}";`
+	setGrantAllRoutinesTemplate    = `GRANT {{.Permission}} ON ALL ROUTINES IN SCHEMA "{{.Schema}}" TO "{{.Role}}";`
+	setGrantDomainTemplate         = `GRANT {{.Permission}} ON DOMAIN "{{.Resource}}" TO "{{.Role}}";`
+	setGrantFdwTemplate            = `GRANT {{.Permission}} ON FOREIGN DATA WRAPPER "{{.Resource}}" TO "{{.Role}}";`
+	setGrantForeignServerTemplate  = `GRANT {{.Permission}} ON FOREIGN SERVER "{{.Resource}}" TO "{{.Role}}";`
+	setGrantLanguageTemplate       = `GRANT {{.Permission}} ON LANGUAGE "{{.Resource}}" TO "{{.Role}}";`
+	setGrantLargeObjectTemplate    = `GRANT {{.Permission}} ON LARGE OBJECT {{.Resource}} TO "{{.Role}}";`
+	setGrantParameterTemplate      = `GRANT {{.Permission}} ON PARAMETER "{{.Resource}}" TO "{{.Role}}";`
+	setGrantTablespaceTemplate     = `GRANT {{.Permission}} ON TABLESPACE "{{.Resource}}" TO "{{.Role}}";`
+	setGrantTypeTemplate           = `GRANT {{.Permission}} ON TYPE "{{.Resource}}" TO "{{.Role}}";`
+	setRevokeInstanceTemplate      = `REVOKE "{{.Permission}}" FROM "{{.Role}}";`
+	setRevokeDatabaseTemplate      = `REVOKE {{.Permission}} ON DATABASE "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeSchemaTemplate        = `REVOKE {{.Permission}} ON SCHEMA "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeTableTemplate         = `REVOKE {{.Permission}} ON TABLE "{{.Schema}}"."{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeAllTablesTemplate     = `REVOKE {{.Permission}} ON ALL TABLES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
+	setRevokeSequenceTemplate      = `REVOKE {{.Permission}} ON SEQUENCE "{{.Schema}}"."{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeAllSequencesTemplate  = `REVOKE {{.Permission}} ON ALL SEQUENCES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
+	setRevokeFunctionTemplate      = `REVOKE {{.Permission}} ON FUNCTION "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
+	setRevokeAllFunctionsTemplate  = `REVOKE {{.Permission}} ON ALL FUNCTIONS IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
+	setRevokeProcedureTemplate     = `REVOKE {{.Permission}} ON PROCEDURE "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
 	setRevokeAllProceduresTemplate = `REVOKE {{.Permission}} ON ALL PROCEDURES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
-	setRevokeRoutineTemplate = `REVOKE {{.Permission}} ON ROUTINE "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
-	setRevokeAllRoutinesTemplate = `REVOKE {{.Permission}} ON ALL ROUTINES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
-	setRevokeDomainTemplate = `REVOKE {{.Permission}} ON DOMAIN "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeFdwTemplate = `REVOKE {{.Permission}} ON FOREIGN DATA WRAPPER "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeRoutineTemplate       = `REVOKE {{.Permission}} ON ROUTINE "{{.Schema}}".{{.Resource}} FROM "{{.Role}}";`
+	setRevokeAllRoutinesTemplate   = `REVOKE {{.Permission}} ON ALL ROUTINES IN SCHEMA "{{.Schema}}" FROM "{{.Role}}";`
+	setRevokeDomainTemplate        = `REVOKE {{.Permission}} ON DOMAIN "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeFdwTemplate           = `REVOKE {{.Permission}} ON FOREIGN DATA WRAPPER "{{.Resource}}" FROM "{{.Role}}";`
 	setRevokeForeignServerTemplate = `REVOKE {{.Permission}} ON FOREIGN SERVER "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeLanguageTemplate = `REVOKE {{.Permission}} ON LANGUAGE "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeLargeObjectTemplate = `REVOKE {{.Permission}} ON LARGE OBJECT {{.Resource}} FROM "{{.Role}}";`
-	setRevokeParameterTemplate = `REVOKE {{.Permission}} ON PARAMETER "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeTablespaceTemplate = `REVOKE {{.Permission}} ON TABLESPACE "{{.Resource}}" FROM "{{.Role}}";`
-	setRevokeTypeTemplate = `REVOKE {{.Permission}} ON TYPE "{{.Resource}}" FROM "{{.Role}}";`
-	setRoleCreateTemplate     = `CREATE ROLE "{{.Name}}" WITH {{ if .Login }}LOGIN {{else}}NOLOGIN {{end}}{{- if .Inherit }}INHERIT {{else}}NOINHERIT {{end}}{{- if .CreateDb }}CREATEDB {{else}}NOCREATEDB {{end}}{{- if .CreateRole }}CREATEROLE {{else}}NOCREATEROLE {{end}}{{- if .Replication }}REPLICATION {{else}}NOREPLICATION {{end}};`
-	setRoleUpdateTemplate     = `ALTER ROLE "{{.Name}}" WITH {{ if .Login }}LOGIN {{else}}NOLOGIN {{end}}{{- if .Inherit }}INHERIT {{else}}NOINHERIT {{end}}{{- if .CreateDb }}CREATEDB {{else}}NOCREATEDB {{end}}{{- if .CreateRole }}CREATEROLE {{else}}NOCREATEROLE {{end}}{{- if .Replication }}REPLICATION {{else}}NOREPLICATION {{end}};`
-	setRoleDeleteTemplate     = `DROP ROLE "{{.Name}}";`
+	setRevokeLanguageTemplate      = `REVOKE {{.Permission}} ON LANGUAGE "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeLargeObjectTemplate   = `REVOKE {{.Permission}} ON LARGE OBJECT {{.Resource}} FROM "{{.Role}}";`
+	setRevokeParameterTemplate     = `REVOKE {{.Permission}} ON PARAMETER "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeTablespaceTemplate    = `REVOKE {{.Permission}} ON TABLESPACE "{{.Resource}}" FROM "{{.Role}}";`
+	setRevokeTypeTemplate          = `REVOKE {{.Permission}} ON TYPE "{{.Resource}}" FROM "{{.Role}}";`
+	setRoleCreateTemplate          = `CREATE ROLE "{{.Name}}" WITH {{ if .Login }}LOGIN {{else}}NOLOGIN {{end}}{{- if .Inherit }}INHERIT {{else}}NOINHERIT {{end}}{{- if .CreateDb }}CREATEDB {{else}}NOCREATEDB {{end}}{{- if .CreateRole }}CREATEROLE {{else}}NOCREATEROLE {{end}}{{- if .Replication }}REPLICATION {{else}}NOREPLICATION {{end}};`
+	setRoleUpdateTemplate          = `ALTER ROLE "{{.Name}}" WITH {{ if .Login }}LOGIN {{else}}NOLOGIN {{end}}{{- if .Inherit }}INHERIT {{else}}NOINHERIT {{end}}{{- if .CreateDb }}CREATEDB {{else}}NOCREATEDB {{end}}{{- if .CreateRole }}CREATEROLE {{else}}NOCREATEROLE {{end}}{{- if .Replication }}REPLICATION {{else}}NOREPLICATION {{end}};`
+	setRoleDeleteTemplate          = `DROP ROLE "{{.Name}}";`
 )
 
 // cleanQuery converts a multi-line, user-readable SQL query into a format that is easier / cleaner


### PR DESCRIPTION
On older versions of PostgreSQL, permissions associated with `ALL PERMISSIONS` return an error code 22023. E.g. checking for `MAINTAIN` on a table for PG version < 17.