### PR TITLE
fix: Add `userinfo.email` scope to GCP access token

### DIFF
--- a/modules/google/cloud/cloud.go
+++ b/modules/google/cloud/cloud.go
@@ -90,7 +90,11 @@ func extractGoogleAPIErrorDescription(body string) string {
 // 2. A JSON file in a well-known location created by the gcloud command-line tool.
 // 3. Credentials from the metadata server on GCE, GKE, App Engine, Cloud Run, and others.
 func DefaultCredentials(ctx context.Context) (*google.Credentials, error) {
-	adc, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	adc, err := google.FindDefaultCredentials(
+		ctx,
+		"https://www.googleapis.com/auth/cloud-platform",
+		"https://www.googleapis.com/auth/userinfo.email", // This is required to read the email from the access token
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -170,5 +174,13 @@ func iamUserWithResolver(
 		}
 	}
 
-	return tokenEmailResolver(ctx, creds)
+	user, err := tokenEmailResolver(ctx, creds)
+	if err != nil {
+		return "", err
+	}
+	user = strings.TrimSpace(user)
+	if user != "" {
+		return user, nil
+	}
+	return "", fmt.Errorf("failed to resolve current IAM identity from provided credentials")
 }

--- a/modules/google/cloud/cloud_test.go
+++ b/modules/google/cloud/cloud_test.go
@@ -197,6 +197,21 @@ func TestIamUser_EmptyJSONFallsBackToTokenInspection(t *testing.T) {
 	require.Equal(t, "wi-principal@example.com", got)
 }
 
+func TestIamUser_EmptyTokenEmailReturnsError(t *testing.T) {
+	creds := &google.Credentials{}
+
+	got, err := iamUserWithResolver(
+		context.Background(),
+		creds,
+		func(_ context.Context, _ *google.Credentials) (string, error) {
+			return "", nil
+		},
+	)
+	require.Error(t, err)
+	require.Empty(t, got)
+	require.Contains(t, err.Error(), "failed to resolve current IAM identity from provided credentials")
+}
+
 func TestSanitizeGoogleAPIError_UsesErrorDescriptionFromBody(t *testing.T) {
 	err := sanitizeGoogleAPIError(
 		"token info",


### PR DESCRIPTION
This fixes an issue where Blackstart cannot determine the user of a google.Credentials object.