### PR TITLE
feat!: Add support for and default to read-only Kubernetes ConfigMap and Secret values

### DIFF
--- a/docs/user-guide/modules/Kubernetes/configmap_value.md
+++ b/docs/user-guide/modules/Kubernetes/configmap_value.md
@@ -25,12 +25,12 @@ and Secrets. The following update policies are supported:
 
 ## Inputs
 
-| Id            | Description                                                       | Type                   | Required |
-| ------------- | ----------------------------------------------------------------- | ---------------------- | -------- |
-| configmap     | ConfigMap resource                                                | \*kubernetes.configMap | true     |
-| key           | Key in the ConfigMap to set                                       | string                 | true     |
-| update_policy | Update policy for the key-value pair<br>Default: **preserve_any** | string                 | false    |
-| value         | Value to set for the key                                          | string                 | true     |
+| Id            | Description                                                                                             | Type                   | Required |
+| ------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | -------- |
+| configmap     | ConfigMap resource                                                                                      | \*kubernetes.configMap | true     |
+| key           | Key in the ConfigMap to set                                                                             | string                 | true     |
+| update_policy | Update policy for the key-value pair<br>Default: **preserve_any**                                       | string                 | false    |
+| value         | Value to set for the key. Required unless `update_policy` is `preserve_any`. Empty strings are allowed. | string                 | false    |
 
 ## Outputs
 
@@ -51,7 +51,6 @@ inputs:
       id: app-configmap
       output: configmap
   key: DATABASE_URL
-  value: ""
   update_policy: preserve_any
 ```
 

--- a/docs/user-guide/modules/Kubernetes/configmap_value.md
+++ b/docs/user-guide/modules/Kubernetes/configmap_value.md
@@ -33,9 +33,26 @@ and Secrets. The following update policies are supported:
 
 ## Outputs
 
-No outputs are supported for this module
+| Id    | Description                                            | Type   |
+| ----- | ------------------------------------------------------ | ------ |
+| value | Current value stored for the key after reconciliation. | string |
 
 ## Examples
+
+### Read ConfigMap Value
+
+```yaml
+id: read-configmap-value
+module: kubernetes_configmap_value
+inputs:
+  configmap:
+    fromDependency:
+      id: app-configmap
+      output: configmap
+  key: DATABASE_URL
+  value: ""
+  update_policy: preserve_any
+```
 
 ### Set ConfigMap Value
 

--- a/docs/user-guide/modules/Kubernetes/configmap_value.md
+++ b/docs/user-guide/modules/Kubernetes/configmap_value.md
@@ -51,7 +51,6 @@ inputs:
       id: app-configmap
       output: configmap
   key: DATABASE_URL
-  update_policy: preserve_any
 ```
 
 ### Set ConfigMap Value

--- a/docs/user-guide/modules/Kubernetes/configmap_value.md
+++ b/docs/user-guide/modules/Kubernetes/configmap_value.md
@@ -11,9 +11,10 @@ Manages key-value pairs in a Kubernetes ConfigMap resource.
 Update policies control how existing values are handled when setting key-value pairs in ConfigMaps
 and Secrets. The following update policies are supported:
 
+- `preserve_any` - Any existing value will be preserved. To avoid any accidental changes, this is
+  the default update policy.
 - `overwrite` - Existing values will be overwritten if they differ from the new value.
 - `preserve` - Any non-empty, existing value will be preserved.
-- `preserve_any` - Any existing value will be preserved.
 - `fail` - If the new value differs from the existing value, the operation will fail.
 
 ## Requirements
@@ -24,12 +25,12 @@ and Secrets. The following update policies are supported:
 
 ## Inputs
 
-| Id            | Description                                                    | Type                   | Required |
-| ------------- | -------------------------------------------------------------- | ---------------------- | -------- |
-| configmap     | ConfigMap resource                                             | \*kubernetes.configMap | true     |
-| key           | Key in the ConfigMap to set                                    | string                 | true     |
-| update_policy | Update policy for the key-value pair<br>Default: **overwrite** | string                 | false    |
-| value         | Value to set for the key                                       | string                 | true     |
+| Id            | Description                                                       | Type                   | Required |
+| ------------- | ----------------------------------------------------------------- | ---------------------- | -------- |
+| configmap     | ConfigMap resource                                                | \*kubernetes.configMap | true     |
+| key           | Key in the ConfigMap to set                                       | string                 | true     |
+| update_policy | Update policy for the key-value pair<br>Default: **preserve_any** | string                 | false    |
+| value         | Value to set for the key                                          | string                 | true     |
 
 ## Outputs
 
@@ -66,4 +67,5 @@ inputs:
       output: configmap
   key: DATABASE_URL
   value: postgres://user:password@localhost:5432/db
+  update_policy: overwrite
 ```

--- a/docs/user-guide/modules/Kubernetes/secret_value.md
+++ b/docs/user-guide/modules/Kubernetes/secret_value.md
@@ -33,9 +33,26 @@ and Secrets. The following update policies are supported:
 
 ## Outputs
 
-No outputs are supported for this module
+| Id    | Description                                            | Type   |
+| ----- | ------------------------------------------------------ | ------ |
+| value | Current value stored for the key after reconciliation. | string |
 
 ## Examples
+
+### Read Secret Value
+
+```yaml
+id: read-secret-value
+module: kubernetes_secret_value
+inputs:
+  secret:
+    fromDependency:
+      id: app-secret
+      output: secret
+  key: DATABASE_PASSWORD
+  value: ""
+  update_policy: preserve_any
+```
 
 ### Set Secret Value
 

--- a/docs/user-guide/modules/Kubernetes/secret_value.md
+++ b/docs/user-guide/modules/Kubernetes/secret_value.md
@@ -11,9 +11,10 @@ Manages key-value pairs in a Kubernetes Secret resource.
 Update policies control how existing values are handled when setting key-value pairs in ConfigMaps
 and Secrets. The following update policies are supported:
 
+- `preserve_any` - Any existing value will be preserved. To avoid any accidental changes, this is
+  the default update policy.
 - `overwrite` - Existing values will be overwritten if they differ from the new value.
 - `preserve` - Any non-empty, existing value will be preserved.
-- `preserve_any` - Any existing value will be preserved.
 - `fail` - If the new value differs from the existing value, the operation will fail.
 
 ## Requirements
@@ -24,12 +25,12 @@ and Secrets. The following update policies are supported:
 
 ## Inputs
 
-| Id            | Description                                                    | Type                | Required |
-| ------------- | -------------------------------------------------------------- | ------------------- | -------- |
-| key           | Key in the Secret to set                                       | string              | true     |
-| secret        | Secret resource                                                | \*kubernetes.secret | true     |
-| update_policy | Update policy for the key-value pair<br>Default: **overwrite** | string              | false    |
-| value         | Value to set for the key                                       | string              | true     |
+| Id            | Description                                                       | Type                | Required |
+| ------------- | ----------------------------------------------------------------- | ------------------- | -------- |
+| key           | Key in the Secret to set                                          | string              | true     |
+| secret        | Secret resource                                                   | \*kubernetes.secret | true     |
+| update_policy | Update policy for the key-value pair<br>Default: **preserve_any** | string              | false    |
+| value         | Value to set for the key                                          | string              | true     |
 
 ## Outputs
 
@@ -66,4 +67,5 @@ inputs:
       output: secret
   key: DATABASE_PASSWORD
   value: supersecretpassword
+  update_policy: overwrite
 ```

--- a/docs/user-guide/modules/Kubernetes/secret_value.md
+++ b/docs/user-guide/modules/Kubernetes/secret_value.md
@@ -51,7 +51,6 @@ inputs:
       id: app-secret
       output: secret
   key: DATABASE_PASSWORD
-  update_policy: preserve_any
 ```
 
 ### Set Secret Value

--- a/docs/user-guide/modules/Kubernetes/secret_value.md
+++ b/docs/user-guide/modules/Kubernetes/secret_value.md
@@ -25,12 +25,12 @@ and Secrets. The following update policies are supported:
 
 ## Inputs
 
-| Id            | Description                                                       | Type                | Required |
-| ------------- | ----------------------------------------------------------------- | ------------------- | -------- |
-| key           | Key in the Secret to set                                          | string              | true     |
-| secret        | Secret resource                                                   | \*kubernetes.secret | true     |
-| update_policy | Update policy for the key-value pair<br>Default: **preserve_any** | string              | false    |
-| value         | Value to set for the key                                          | string              | true     |
+| Id            | Description                                                                                             | Type                | Required |
+| ------------- | ------------------------------------------------------------------------------------------------------- | ------------------- | -------- |
+| key           | Key in the Secret to set                                                                                | string              | true     |
+| secret        | Secret resource                                                                                         | \*kubernetes.secret | true     |
+| update_policy | Update policy for the key-value pair<br>Default: **preserve_any**                                       | string              | false    |
+| value         | Value to set for the key. Required unless `update_policy` is `preserve_any`. Empty strings are allowed. | string              | false    |
 
 ## Outputs
 
@@ -51,7 +51,6 @@ inputs:
       id: app-secret
       output: secret
   key: DATABASE_PASSWORD
-  value: ""
   update_policy: preserve_any
 ```
 

--- a/docs/user-guide/workflows.md
+++ b/docs/user-guide/workflows.md
@@ -194,4 +194,3 @@ inputs:
 In this case, the `connection` input will be populated with the value of the `connection` output
 from the `test_instance` operation. This also creates a dependency on `test_instance` in the
 generated execution graph.
-

--- a/modules/kubernetes/configmap_value.go
+++ b/modules/kubernetes/configmap_value.go
@@ -52,8 +52,23 @@ func (c *configMapValueModule) Info() blackstart.ModuleInfo {
 				Default:     updatePolicyOverwrite,
 			},
 		},
-		Outputs: map[string]blackstart.OutputValue{},
+		Outputs: map[string]blackstart.OutputValue{
+			outputValue: {
+				Description: "Current value stored for the key after reconciliation.",
+				Type:        reflect.TypeFor[string](),
+			},
+		},
 		Examples: map[string]string{
+			"Read ConfigMap Value": `id: read-configmap-value
+module: kubernetes_configmap_value
+inputs:
+  configmap:
+    fromDependency:
+      id: app-configmap
+      output: configmap
+  key: DATABASE_URL
+  value: ""
+  update_policy: preserve_any`,
 			"Set ConfigMap Value": `id: set-configmap-example
 module: kubernetes_configmap_value
 inputs:
@@ -119,10 +134,6 @@ func (c *configMapValueModule) Validate(op blackstart.Operation) error {
 }
 
 func (c *configMapValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
-	if ctx.Tainted() {
-		return false, nil
-	}
-
 	cmInput, err := ctx.Input(inputConfigMap)
 	if err != nil {
 		return false, fmt.Errorf("failed to get ConfigMap: %w", err)
@@ -155,6 +166,10 @@ func (c *configMapValueModule) Check(ctx blackstart.ModuleContext) (bool, error)
 		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
 	}
 
+	if ctx.Tainted() {
+		return false, nil
+	}
+
 	// If DoesNotExist is true, success is either the ConfigMap or key does not exist
 	if ctx.DoesNotExist() {
 		_, keyExists := cm.cm.Data[key]
@@ -172,21 +187,24 @@ func (c *configMapValueModule) Check(ctx blackstart.ModuleContext) (bool, error)
 
 	switch updatePolicy {
 	case updatePolicyOverwrite:
-		return actualValue == desiredValue, nil
+		if actualValue == desiredValue {
+			return true, outputConfigMapValue(ctx, actualValue)
+		}
+		return false, nil
 	case updatePolicyPreserve:
 		if actualValue != "" {
-			return true, nil
+			return true, outputConfigMapValue(ctx, actualValue)
 		}
 		return false, nil
 	case updatePolicyPreserveAny:
-		return true, nil
+		return true, outputConfigMapValue(ctx, actualValue)
 	case updatePolicyFail:
 		if actualValue != desiredValue {
 			return false, fmt.Errorf(
 				"key '%s' had a value changed, but updating the value is not allowed due to the update policy", key,
 			)
 		}
-		return true, nil
+		return true, outputConfigMapValue(ctx, actualValue)
 	}
 	return false, fmt.Errorf("unhandled update policy: %s", updatePolicy)
 }
@@ -223,10 +241,19 @@ func (c *configMapValueModule) Set(ctx blackstart.ModuleContext) error {
 			delete(cm.cm.Data, key)
 			return cm.Update(ctx)
 		}
+		return nil
 	}
 
 	// ConfigMap exists, update the value
 	cm.cm.Data[key] = desiredValue
 
-	return cm.Update(ctx)
+	if err := cm.Update(ctx); err != nil {
+		return err
+	}
+	return outputConfigMapValue(ctx, desiredValue)
+}
+
+// outputConfigMapValue emits the value output for a ConfigMap key.
+func outputConfigMapValue(ctx blackstart.ModuleContext, value string) error {
+	return ctx.Output(outputValue, value)
 }

--- a/modules/kubernetes/configmap_value.go
+++ b/modules/kubernetes/configmap_value.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/pezops/blackstart"
 )
@@ -41,9 +40,9 @@ func (c *configMapValueModule) Info() blackstart.ModuleInfo {
 				Required:    true,
 			},
 			inputValue: {
-				Description: "Value to set for the key",
+				Description: "Value to set for the key. Required unless `update_policy` is `preserve_any`. Empty strings are allowed.",
 				Type:        reflect.TypeFor[string](),
-				Required:    true,
+				Required:    false,
 			},
 			inputUpdatePolicy: {
 				Description: "Update policy for the key-value pair",
@@ -67,7 +66,6 @@ inputs:
       id: app-configmap
       output: configmap
   key: DATABASE_URL
-  value: ""
   update_policy: preserve_any`,
 			"Set ConfigMap Value": `id: set-configmap-example
 module: kubernetes_configmap_value
@@ -99,36 +97,18 @@ func (c *configMapValueModule) Validate(op blackstart.Operation) error {
 		}
 	}
 
-	// Value is required (but can be an empty string)
-	_, ok = op.Inputs[inputValue]
-	if !ok {
-		return fmt.Errorf("input '%s' must be provided", inputValue)
-	}
-
 	// ConfigMap is required
 	_, ok = op.Inputs[inputConfigMap]
 	if !ok {
 		return fmt.Errorf("input '%s' must be provided", inputConfigMap)
 	}
 
-	updatePolicy := updatePolicyPreserveAny
-	if updatePolicyInput, exists := op.Inputs[inputUpdatePolicy]; exists {
-		if !updatePolicyInput.IsStatic() {
-			return nil
-		}
-		updatePolicyValue, err := blackstart.InputAs[string](updatePolicyInput, false)
-		if err != nil {
-			return fmt.Errorf("input '%s' is invalid: %w", inputUpdatePolicy, err)
-		}
-		updatePolicy = strings.TrimSpace(updatePolicyValue)
-		if updatePolicy == "" {
-			updatePolicy = updatePolicyPreserveAny
-		}
+	updatePolicy, policyKnown, err := operationUpdatePolicy(op)
+	if err != nil {
+		return err
 	}
-
-	_, ok = updatePolicies[updatePolicy]
-	if !ok {
-		return fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	if err = validateValueInput(op, updatePolicy, policyKnown); err != nil {
+		return err
 	}
 
 	return nil
@@ -150,21 +130,17 @@ func (c *configMapValueModule) Check(ctx blackstart.ModuleContext) (bool, error)
 		return false, err
 	}
 
-	desiredValue, err := blackstart.ContextInputAs[string](ctx, inputValue, true)
+	updatePolicy, err := contextUpdatePolicy(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	updatePolicy := updatePolicyPreserveAny
-	updatePolicyInput, inputErr := blackstart.ContextInputAs[string](ctx, inputUpdatePolicy, false)
-	if inputErr == nil {
-		updatePolicy = strings.TrimSpace(updatePolicyInput)
+	desiredValue, hasValue, err := contextOptionalValue(ctx)
+	if err != nil {
+		return false, err
 	}
-	if updatePolicy == "" {
-		updatePolicy = updatePolicyPreserveAny
-	}
-	if _, ok := updatePolicies[updatePolicy]; !ok {
-		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	if err = requireValueInput(updatePolicy, hasValue); err != nil {
+		return false, err
 	}
 
 	if ctx.Tainted() {
@@ -226,7 +202,7 @@ func (c *configMapValueModule) Set(ctx blackstart.ModuleContext) error {
 		return err
 	}
 
-	desiredValue, err := blackstart.ContextInputAs[string](ctx, inputValue, true)
+	desiredValue, hasValue, err := contextOptionalValue(ctx)
 	if err != nil {
 		return err
 	}
@@ -245,10 +221,14 @@ func (c *configMapValueModule) Set(ctx blackstart.ModuleContext) error {
 		return nil
 	}
 
+	if err = requireSetValueInput(hasValue); err != nil {
+		return err
+	}
+
 	// ConfigMap exists, update the value
 	cm.cm.Data[key] = desiredValue
 
-	if err := cm.Update(ctx); err != nil {
+	if err = cm.Update(ctx); err != nil {
 		return err
 	}
 	return outputConfigMapValue(ctx, desiredValue)

--- a/modules/kubernetes/configmap_value.go
+++ b/modules/kubernetes/configmap_value.go
@@ -49,7 +49,7 @@ func (c *configMapValueModule) Info() blackstart.ModuleInfo {
 				Description: "Update policy for the key-value pair",
 				Type:        reflect.TypeFor[string](),
 				Required:    false,
-				Default:     updatePolicyOverwrite,
+				Default:     updatePolicyPreserveAny,
 			},
 		},
 		Outputs: map[string]blackstart.OutputValue{
@@ -77,7 +77,8 @@ inputs:
       id: app-configmap
       output: configmap
   key: DATABASE_URL
-  value: postgres://user:password@localhost:5432/db`,
+  value: postgres://user:password@localhost:5432/db
+  update_policy: overwrite`,
 		},
 	}
 }
@@ -110,7 +111,7 @@ func (c *configMapValueModule) Validate(op blackstart.Operation) error {
 		return fmt.Errorf("input '%s' must be provided", inputConfigMap)
 	}
 
-	updatePolicy := updatePolicyOverwrite
+	updatePolicy := updatePolicyPreserveAny
 	if updatePolicyInput, exists := op.Inputs[inputUpdatePolicy]; exists {
 		if !updatePolicyInput.IsStatic() {
 			return nil
@@ -121,7 +122,7 @@ func (c *configMapValueModule) Validate(op blackstart.Operation) error {
 		}
 		updatePolicy = strings.TrimSpace(updatePolicyValue)
 		if updatePolicy == "" {
-			updatePolicy = updatePolicyOverwrite
+			updatePolicy = updatePolicyPreserveAny
 		}
 	}
 
@@ -154,13 +155,13 @@ func (c *configMapValueModule) Check(ctx blackstart.ModuleContext) (bool, error)
 		return false, err
 	}
 
-	updatePolicy := updatePolicyOverwrite
+	updatePolicy := updatePolicyPreserveAny
 	updatePolicyInput, inputErr := blackstart.ContextInputAs[string](ctx, inputUpdatePolicy, false)
 	if inputErr == nil {
 		updatePolicy = strings.TrimSpace(updatePolicyInput)
 	}
 	if updatePolicy == "" {
-		updatePolicy = updatePolicyOverwrite
+		updatePolicy = updatePolicyPreserveAny
 	}
 	if _, ok := updatePolicies[updatePolicy]; !ok {
 		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)

--- a/modules/kubernetes/configmap_value.go
+++ b/modules/kubernetes/configmap_value.go
@@ -65,8 +65,7 @@ inputs:
     fromDependency:
       id: app-configmap
       output: configmap
-  key: DATABASE_URL
-  update_policy: preserve_any`,
+  key: DATABASE_URL`,
 			"Set ConfigMap Value": `id: set-configmap-example
 module: kubernetes_configmap_value
 inputs:

--- a/modules/kubernetes/configmap_value_test.go
+++ b/modules/kubernetes/configmap_value_test.go
@@ -477,7 +477,7 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 	}
 }
 
-func TestConfigMapValueModule_CheckOutputsCurrentValue(t *testing.T) {
+func TestConfigMapValueModule_CheckOutputsSupportedValueStates(t *testing.T) {
 	clientset := fake.NewClientset()
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -485,26 +485,45 @@ func TestConfigMapValueModule_CheckOutputsCurrentValue(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string]string{
-			"private-key": "stored-private-key",
+			"string-key": "stored-value",
+			"empty-key":  "",
 		},
 	}
 
 	module := NewConfigMapValueModule()
-	inputs := map[string]blackstart.Input{
-		inputConfigMap: blackstart.NewInputFromValue(&configMap{
-			cm:  cm,
-			cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
-		}),
-		inputKey:          blackstart.NewInputFromValue("private-key"),
-		inputValue:        blackstart.NewInputFromValue("new-private-key"),
-		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserve),
+	tests := []struct {
+		name       string
+		key        string
+		wantResult bool
+		wantOutput bool
+		wantValue  string
+	}{
+		{name: "string_value", key: "string-key", wantResult: true, wantOutput: true, wantValue: "stored-value"},
+		{name: "empty_string_value", key: "empty-key", wantResult: true, wantOutput: true, wantValue: ""},
+		{name: "missing_key", key: "missing-key", wantResult: false},
 	}
-	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputs := map[string]blackstart.Input{
+				inputConfigMap: blackstart.NewInputFromValue(&configMap{
+					cm:  cm,
+					cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
+				}),
+				inputKey: blackstart.NewInputFromValue(tt.key),
+			}
+			ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
 
-	result, err := module.Check(ctx)
-	require.NoError(t, err)
-	assert.True(t, result)
-	assert.Equal(t, "stored-private-key", ctx.outputs[outputValue])
+			result, err := module.Check(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, result)
+			if tt.wantOutput {
+				assert.Equal(t, tt.wantValue, ctx.outputs[outputValue])
+				assert.IsType(t, "", ctx.outputs[outputValue])
+			} else {
+				assert.NotContains(t, ctx.outputs, outputValue)
+			}
+		})
+	}
 }
 
 func TestConfigMapValueModule_Set(t *testing.T) {

--- a/modules/kubernetes/configmap_value_test.go
+++ b/modules/kubernetes/configmap_value_test.go
@@ -24,6 +24,7 @@ func TestConfigMapValueModule_Info(t *testing.T) {
 	assert.True(t, exists)
 	_, exists = info.Inputs[inputValue]
 	assert.True(t, exists)
+	assert.False(t, info.Inputs[inputValue].Required)
 	_, exists = info.Inputs[inputConfigMap]
 	assert.True(t, exists)
 	_, exists = info.Outputs[outputValue]
@@ -79,11 +80,37 @@ func TestConfigMapValueModule_Validate(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "missing value",
+			name: "missing value with overwrite",
 			inputs: map[string]blackstart.Input{
 				inputConfigMap:    blackstart.NewInputFromValue(cm),
 				inputKey:          blackstart.NewInputFromValue("test-key"),
 				inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyOverwrite),
+			},
+			expectError: true,
+		},
+		{
+			name: "missing value with preserve_any",
+			inputs: map[string]blackstart.Input{
+				inputConfigMap:    blackstart.NewInputFromValue(cm),
+				inputKey:          blackstart.NewInputFromValue("test-key"),
+				inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserveAny),
+			},
+			expectError: false,
+		},
+		{
+			name: "missing value defaults to preserve_any",
+			inputs: map[string]blackstart.Input{
+				inputConfigMap: blackstart.NewInputFromValue(cm),
+				inputKey:       blackstart.NewInputFromValue("test-key"),
+			},
+			expectError: false,
+		},
+		{
+			name: "null value is invalid",
+			inputs: map[string]blackstart.Input{
+				inputConfigMap: blackstart.NewInputFromValue(cm),
+				inputKey:       blackstart.NewInputFromValue("test-key"),
+				inputValue:     blackstart.NewInputFromValue(nil),
 			},
 			expectError: true,
 		},
@@ -178,6 +205,7 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 		namespace      string
 		key            string
 		value          string
+		omitValue      bool
 		updatePolicy   string
 		doesNotExist   bool
 		tainted        bool
@@ -286,6 +314,34 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 			updatePolicy:   updatePolicyPreserveAny,
 			expectedResult: false,
 		},
+		{
+			name:           "preserve_any policy with non-empty existing value and omitted value",
+			configMapName:  "test-configmap",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyPreserveAny,
+			expectedResult: true,
+		},
+		{
+			name:           "preserve_any policy with missing key and omitted value",
+			configMapName:  "test-configmap",
+			namespace:      "test-namespace",
+			key:            "missing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyPreserveAny,
+			expectedResult: false,
+		},
+		{
+			name:           "overwrite policy with omitted value",
+			configMapName:  "test-configmap",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyOverwrite,
+			expectedResult: false,
+			expectError:    true,
+		},
 		// Fail policy tests
 		{
 			name:           "fail policy with matching value",
@@ -388,8 +444,10 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 				inputs := map[string]blackstart.Input{
 					inputConfigMap:    blackstart.NewInputFromValue(configMapObj),
 					inputKey:          blackstart.NewInputFromValue(test.key),
-					inputValue:        blackstart.NewInputFromValue(test.value),
 					inputUpdatePolicy: blackstart.NewInputFromValue(test.updatePolicy),
+				}
+				if !test.omitValue {
+					inputs[inputValue] = blackstart.NewInputFromValue(test.value)
 				}
 
 				// Create context using blackstart.InputsToContext
@@ -621,6 +679,76 @@ func TestConfigMapValueModule_SetOutputsWrittenValue(t *testing.T) {
 	err = module.Set(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "generated-private-key", ctx.outputs[outputValue])
+}
+
+func TestConfigMapValueModule_SetRejectsOmittedValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{},
+	}
+	_, err := clientset.CoreV1().ConfigMaps("test-namespace").Create(
+		context.Background(),
+		initialConfigMap,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewConfigMapValueModule()
+	inputs := map[string]blackstart.Input{
+		inputConfigMap: blackstart.NewInputFromValue(&configMap{
+			cm:  initialConfigMap,
+			cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
+		}),
+		inputKey:          blackstart.NewInputFromValue("missing-key"),
+		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserveAny),
+	}
+	ctx := blackstart.InputsToContext(context.Background(), inputs)
+
+	err = module.Set(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be provided when setting a missing key")
+}
+
+func TestConfigMapValueModule_SetAllowsEmptyStringValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{},
+	}
+	_, err := clientset.CoreV1().ConfigMaps("test-namespace").Create(
+		context.Background(),
+		initialConfigMap,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewConfigMapValueModule()
+	inputs := map[string]blackstart.Input{
+		inputConfigMap: blackstart.NewInputFromValue(&configMap{
+			cm:  initialConfigMap,
+			cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
+		}),
+		inputKey:   blackstart.NewInputFromValue("empty-key"),
+		inputValue: blackstart.NewInputFromValue(""),
+	}
+	ctx := blackstart.InputsToContext(context.Background(), inputs)
+
+	err = module.Set(ctx)
+	require.NoError(t, err)
+	cm, err := clientset.CoreV1().ConfigMaps("test-namespace").Get(
+		context.Background(),
+		"test-configmap",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "", cm.Data["empty-key"])
 }
 
 func TestConfigMapValueModule(t *testing.T) {

--- a/modules/kubernetes/configmap_value_test.go
+++ b/modules/kubernetes/configmap_value_test.go
@@ -26,6 +26,8 @@ func TestConfigMapValueModule_Info(t *testing.T) {
 	assert.True(t, exists)
 	_, exists = info.Inputs[inputConfigMap]
 	assert.True(t, exists)
+	_, exists = info.Outputs[outputValue]
+	assert.True(t, exists)
 }
 
 func TestConfigMapValueModule_Validate(t *testing.T) {
@@ -408,6 +410,36 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 	}
 }
 
+func TestConfigMapValueModule_CheckOutputsCurrentValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{
+			"private-key": "stored-private-key",
+		},
+	}
+
+	module := NewConfigMapValueModule()
+	inputs := map[string]blackstart.Input{
+		inputConfigMap: blackstart.NewInputFromValue(&configMap{
+			cm:  cm,
+			cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
+		}),
+		inputKey:          blackstart.NewInputFromValue("private-key"),
+		inputValue:        blackstart.NewInputFromValue("new-private-key"),
+		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserve),
+	}
+	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+
+	result, err := module.Check(ctx)
+	require.NoError(t, err)
+	assert.True(t, result)
+	assert.Equal(t, "stored-private-key", ctx.outputs[outputValue])
+}
+
 func TestConfigMapValueModule_Set(t *testing.T) {
 	// Create a fake Kubernetes clientset
 	clientset := fake.NewClientset()
@@ -548,6 +580,38 @@ func TestConfigMapValueModule_Set(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestConfigMapValueModule_SetOutputsWrittenValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "test-namespace",
+		},
+		Data: map[string]string{},
+	}
+	_, err := clientset.CoreV1().ConfigMaps("test-namespace").Create(
+		context.Background(),
+		initialConfigMap,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewConfigMapValueModule()
+	inputs := map[string]blackstart.Input{
+		inputConfigMap: blackstart.NewInputFromValue(&configMap{
+			cm:  initialConfigMap,
+			cmi: clientset.CoreV1().ConfigMaps("test-namespace"),
+		}),
+		inputKey:   blackstart.NewInputFromValue("private-key"),
+		inputValue: blackstart.NewInputFromValue("generated-private-key"),
+	}
+	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+
+	err = module.Set(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "generated-private-key", ctx.outputs[outputValue])
 }
 
 func TestConfigMapValueModule(t *testing.T) {

--- a/modules/kubernetes/configmap_value_test.go
+++ b/modules/kubernetes/configmap_value_test.go
@@ -108,7 +108,7 @@ func TestConfigMapValueModule_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "missing update policy defaults to overwrite",
+			name: "missing update policy defaults to preserve_any",
 			inputs: map[string]blackstart.Input{
 				inputConfigMap: blackstart.NewInputFromValue(cm),
 				inputKey:       blackstart.NewInputFromValue("test-key"),
@@ -213,11 +213,20 @@ func TestConfigMapValueModule_Check(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "existing configmap existing key correct value - empty policy defaults to overwrite",
+			name:           "existing configmap existing key correct value - empty policy defaults to preserve_any",
 			configMapName:  "test-configmap",
 			namespace:      "test-namespace",
 			key:            "existing-key",
 			value:          "existing-value",
+			updatePolicy:   "",
+			expectedResult: true,
+		},
+		{
+			name:           "existing configmap existing key different value - empty policy defaults to preserve_any",
+			configMapName:  "test-configmap",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			value:          "different-value",
 			updatePolicy:   "",
 			expectedResult: true,
 		},

--- a/modules/kubernetes/kubernetes.go
+++ b/modules/kubernetes/kubernetes.go
@@ -42,9 +42,9 @@ var updatePolicyDocs = util.CleanString(
 Update policies control how existing values are handled when setting key-value pairs in ConfigMaps 
 and Secrets. The following update policies are supported:
 
+- '''preserve_any''' - Any existing value will be preserved. To avoid any accidental changes, this is the default update policy.
 - '''overwrite''' - Existing values will be overwritten if they differ from the new value.
 - '''preserve''' - Any non-empty, existing value will be preserved.
-- '''preserve_any''' - Any existing value will be preserved.
 - '''fail''' - If the new value differs from the existing value, the operation will fail.
 
 `,

--- a/modules/kubernetes/kubernetes.go
+++ b/modules/kubernetes/kubernetes.go
@@ -18,6 +18,7 @@ const (
 	outputConfigMap = "configmap"
 	outputSecret    = "secret"
 	outputClient    = "client"
+	outputValue     = "value"
 )
 
 const (

--- a/modules/kubernetes/secret_value.go
+++ b/modules/kubernetes/secret_value.go
@@ -52,8 +52,23 @@ func (s *secretValueModule) Info() blackstart.ModuleInfo {
 				Default:     updatePolicyOverwrite,
 			},
 		},
-		Outputs: map[string]blackstart.OutputValue{},
+		Outputs: map[string]blackstart.OutputValue{
+			outputValue: {
+				Description: "Current value stored for the key after reconciliation.",
+				Type:        reflect.TypeFor[string](),
+			},
+		},
 		Examples: map[string]string{
+			"Read Secret Value": `id: read-secret-value
+module: kubernetes_secret_value
+inputs:
+  secret:
+    fromDependency:
+      id: app-secret
+      output: secret
+  key: DATABASE_PASSWORD
+  value: ""
+  update_policy: preserve_any`,
 			"Set Secret Value": `id: set-secret-example
 module: kubernetes_secret_value
 inputs:
@@ -119,10 +134,6 @@ func (s *secretValueModule) Validate(op blackstart.Operation) error {
 }
 
 func (s *secretValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
-	if ctx.Tainted() {
-		return false, nil
-	}
-
 	secInput, err := ctx.Input(inputSecret)
 	if err != nil {
 		return false, fmt.Errorf("failed to get Secret: %w", err)
@@ -155,6 +166,10 @@ func (s *secretValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
 	}
 
+	if ctx.Tainted() {
+		return false, nil
+	}
+
 	// If DoesNotExist is true, success is either the Secret or key does not exist
 	if ctx.DoesNotExist() {
 		_, keyExists := sec.s.Data[key]
@@ -173,21 +188,24 @@ func (s *secretValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 
 	switch updatePolicy {
 	case updatePolicyOverwrite:
-		return actualValue == desiredValue, nil
+		if actualValue == desiredValue {
+			return true, outputSecretValue(ctx, actualValue)
+		}
+		return false, nil
 	case updatePolicyPreserve:
 		if actualValue != "" {
-			return true, nil
+			return true, outputSecretValue(ctx, actualValue)
 		}
 		return false, nil
 	case updatePolicyPreserveAny:
-		return true, nil
+		return true, outputSecretValue(ctx, actualValue)
 	case updatePolicyFail:
 		if actualValue != desiredValue {
 			return false, fmt.Errorf(
 				"key '%s' had a value changed, but updating the value is not allowed due to the update policy", key,
 			)
 		}
-		return true, nil
+		return true, outputSecretValue(ctx, actualValue)
 	}
 	return false, fmt.Errorf("unhandled update policy: %s", updatePolicy)
 }
@@ -224,10 +242,19 @@ func (s *secretValueModule) Set(ctx blackstart.ModuleContext) error {
 			delete(sec.s.Data, key)
 			return sec.Update(ctx)
 		}
+		return nil
 	}
 
 	// Secret exists, update the value
 	sec.s.Data[key] = []byte(desiredValue)
 
-	return sec.Update(ctx)
+	if err := sec.Update(ctx); err != nil {
+		return err
+	}
+	return outputSecretValue(ctx, desiredValue)
+}
+
+// outputSecretValue emits the value output for a Secret key.
+func outputSecretValue(ctx blackstart.ModuleContext, value string) error {
+	return ctx.Output(outputValue, value)
 }

--- a/modules/kubernetes/secret_value.go
+++ b/modules/kubernetes/secret_value.go
@@ -49,7 +49,7 @@ func (s *secretValueModule) Info() blackstart.ModuleInfo {
 				Description: "Update policy for the key-value pair",
 				Type:        reflect.TypeFor[string](),
 				Required:    false,
-				Default:     updatePolicyOverwrite,
+				Default:     updatePolicyPreserveAny,
 			},
 		},
 		Outputs: map[string]blackstart.OutputValue{
@@ -77,7 +77,8 @@ inputs:
       id: app-secret
       output: secret
   key: DATABASE_PASSWORD
-  value: supersecretpassword`,
+  value: supersecretpassword
+  update_policy: overwrite`,
 		},
 	}
 }
@@ -110,7 +111,7 @@ func (s *secretValueModule) Validate(op blackstart.Operation) error {
 		return fmt.Errorf("input '%s' must be provided", inputSecret)
 	}
 
-	updatePolicy := updatePolicyOverwrite
+	updatePolicy := updatePolicyPreserveAny
 	if updatePolicyInput, exists := op.Inputs[inputUpdatePolicy]; exists {
 		if !updatePolicyInput.IsStatic() {
 			return nil
@@ -121,7 +122,7 @@ func (s *secretValueModule) Validate(op blackstart.Operation) error {
 		}
 		updatePolicy = strings.TrimSpace(updatePolicyValue)
 		if updatePolicy == "" {
-			updatePolicy = updatePolicyOverwrite
+			updatePolicy = updatePolicyPreserveAny
 		}
 	}
 
@@ -154,13 +155,13 @@ func (s *secretValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 		return false, err
 	}
 
-	updatePolicy := updatePolicyOverwrite
+	updatePolicy := updatePolicyPreserveAny
 	updatePolicyInput, inputErr := blackstart.ContextInputAs[string](ctx, inputUpdatePolicy, false)
 	if inputErr == nil {
 		updatePolicy = strings.TrimSpace(updatePolicyInput)
 	}
 	if updatePolicy == "" {
-		updatePolicy = updatePolicyOverwrite
+		updatePolicy = updatePolicyPreserveAny
 	}
 	if _, ok := updatePolicies[updatePolicy]; !ok {
 		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)

--- a/modules/kubernetes/secret_value.go
+++ b/modules/kubernetes/secret_value.go
@@ -65,8 +65,7 @@ inputs:
     fromDependency:
       id: app-secret
       output: secret
-  key: DATABASE_PASSWORD
-  update_policy: preserve_any`,
+  key: DATABASE_PASSWORD`,
 			"Set Secret Value": `id: set-secret-example
 module: kubernetes_secret_value
 inputs:

--- a/modules/kubernetes/secret_value.go
+++ b/modules/kubernetes/secret_value.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/pezops/blackstart"
 )
@@ -41,9 +40,9 @@ func (s *secretValueModule) Info() blackstart.ModuleInfo {
 				Required:    true,
 			},
 			inputValue: {
-				Description: "Value to set for the key",
+				Description: "Value to set for the key. Required unless `update_policy` is `preserve_any`. Empty strings are allowed.",
 				Type:        reflect.TypeFor[string](),
-				Required:    true,
+				Required:    false,
 			},
 			inputUpdatePolicy: {
 				Description: "Update policy for the key-value pair",
@@ -67,7 +66,6 @@ inputs:
       id: app-secret
       output: secret
   key: DATABASE_PASSWORD
-  value: ""
   update_policy: preserve_any`,
 			"Set Secret Value": `id: set-secret-example
 module: kubernetes_secret_value
@@ -99,36 +97,18 @@ func (s *secretValueModule) Validate(op blackstart.Operation) error {
 		}
 	}
 
-	// Value is required (but can be an empty string)
-	_, ok = op.Inputs[inputValue]
-	if !ok {
-		return fmt.Errorf("input '%s' must be provided", inputValue)
-	}
-
 	// Secret is required
 	_, ok = op.Inputs[inputSecret]
 	if !ok {
 		return fmt.Errorf("input '%s' must be provided", inputSecret)
 	}
 
-	updatePolicy := updatePolicyPreserveAny
-	if updatePolicyInput, exists := op.Inputs[inputUpdatePolicy]; exists {
-		if !updatePolicyInput.IsStatic() {
-			return nil
-		}
-		updatePolicyValue, err := blackstart.InputAs[string](updatePolicyInput, false)
-		if err != nil {
-			return fmt.Errorf("input '%s' is invalid: %w", inputUpdatePolicy, err)
-		}
-		updatePolicy = strings.TrimSpace(updatePolicyValue)
-		if updatePolicy == "" {
-			updatePolicy = updatePolicyPreserveAny
-		}
+	updatePolicy, policyKnown, err := operationUpdatePolicy(op)
+	if err != nil {
+		return err
 	}
-
-	_, ok = updatePolicies[updatePolicy]
-	if !ok {
-		return fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	if err = validateValueInput(op, updatePolicy, policyKnown); err != nil {
+		return err
 	}
 
 	return nil
@@ -150,21 +130,17 @@ func (s *secretValueModule) Check(ctx blackstart.ModuleContext) (bool, error) {
 		return false, err
 	}
 
-	desiredValue, err := blackstart.ContextInputAs[string](ctx, inputValue, true)
+	updatePolicy, err := contextUpdatePolicy(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	updatePolicy := updatePolicyPreserveAny
-	updatePolicyInput, inputErr := blackstart.ContextInputAs[string](ctx, inputUpdatePolicy, false)
-	if inputErr == nil {
-		updatePolicy = strings.TrimSpace(updatePolicyInput)
+	desiredValue, hasValue, err := contextOptionalValue(ctx)
+	if err != nil {
+		return false, err
 	}
-	if updatePolicy == "" {
-		updatePolicy = updatePolicyPreserveAny
-	}
-	if _, ok := updatePolicies[updatePolicy]; !ok {
-		return false, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	if err = requireValueInput(updatePolicy, hasValue); err != nil {
+		return false, err
 	}
 
 	if ctx.Tainted() {
@@ -227,7 +203,7 @@ func (s *secretValueModule) Set(ctx blackstart.ModuleContext) error {
 		return err
 	}
 
-	desiredValue, err := blackstart.ContextInputAs[string](ctx, inputValue, true)
+	desiredValue, hasValue, err := contextOptionalValue(ctx)
 	if err != nil {
 		return err
 	}
@@ -246,10 +222,14 @@ func (s *secretValueModule) Set(ctx blackstart.ModuleContext) error {
 		return nil
 	}
 
+	if err = requireSetValueInput(hasValue); err != nil {
+		return err
+	}
+
 	// Secret exists, update the value
 	sec.s.Data[key] = []byte(desiredValue)
 
-	if err := sec.Update(ctx); err != nil {
+	if err = sec.Update(ctx); err != nil {
 		return err
 	}
 	return outputSecretValue(ctx, desiredValue)

--- a/modules/kubernetes/secret_value_test.go
+++ b/modules/kubernetes/secret_value_test.go
@@ -24,6 +24,7 @@ func TestSecretValueModule_Info(t *testing.T) {
 	assert.True(t, exists)
 	_, exists = info.Inputs[inputValue]
 	assert.True(t, exists)
+	assert.False(t, info.Inputs[inputValue].Required)
 	_, exists = info.Inputs[inputSecret]
 	assert.True(t, exists)
 	_, exists = info.Outputs[outputValue]
@@ -79,11 +80,37 @@ func TestSecretValueModule_Validate(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "missing value",
+			name: "missing value with overwrite",
 			inputs: map[string]blackstart.Input{
 				inputSecret:       blackstart.NewInputFromValue(sec),
 				inputKey:          blackstart.NewInputFromValue("test-key"),
 				inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyOverwrite),
+			},
+			expectError: true,
+		},
+		{
+			name: "missing value with preserve_any",
+			inputs: map[string]blackstart.Input{
+				inputSecret:       blackstart.NewInputFromValue(sec),
+				inputKey:          blackstart.NewInputFromValue("test-key"),
+				inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserveAny),
+			},
+			expectError: false,
+		},
+		{
+			name: "missing value defaults to preserve_any",
+			inputs: map[string]blackstart.Input{
+				inputSecret: blackstart.NewInputFromValue(sec),
+				inputKey:    blackstart.NewInputFromValue("test-key"),
+			},
+			expectError: false,
+		},
+		{
+			name: "null value is invalid",
+			inputs: map[string]blackstart.Input{
+				inputSecret: blackstart.NewInputFromValue(sec),
+				inputKey:    blackstart.NewInputFromValue("test-key"),
+				inputValue:  blackstart.NewInputFromValue(nil),
 			},
 			expectError: true,
 		},
@@ -178,6 +205,7 @@ func TestSecretValueModule_Check(t *testing.T) {
 		namespace      string
 		key            string
 		value          string
+		omitValue      bool
 		updatePolicy   string
 		doesNotExist   bool
 		tainted        bool
@@ -286,6 +314,34 @@ func TestSecretValueModule_Check(t *testing.T) {
 			updatePolicy:   updatePolicyPreserveAny,
 			expectedResult: false,
 		},
+		{
+			name:           "preserve_any policy with non-empty existing value and omitted value",
+			secretName:     "test-secret",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyPreserveAny,
+			expectedResult: true,
+		},
+		{
+			name:           "preserve_any policy with missing key and omitted value",
+			secretName:     "test-secret",
+			namespace:      "test-namespace",
+			key:            "missing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyPreserveAny,
+			expectedResult: false,
+		},
+		{
+			name:           "overwrite policy with omitted value",
+			secretName:     "test-secret",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			omitValue:      true,
+			updatePolicy:   updatePolicyOverwrite,
+			expectedResult: false,
+			expectError:    true,
+		},
 		// Fail policy tests
 		{
 			name:           "fail policy with matching value",
@@ -388,8 +444,10 @@ func TestSecretValueModule_Check(t *testing.T) {
 				inputs := map[string]blackstart.Input{
 					inputSecret:       blackstart.NewInputFromValue(secretObj),
 					inputKey:          blackstart.NewInputFromValue(test.key),
-					inputValue:        blackstart.NewInputFromValue(test.value),
 					inputUpdatePolicy: blackstart.NewInputFromValue(test.updatePolicy),
+				}
+				if !test.omitValue {
+					inputs[inputValue] = blackstart.NewInputFromValue(test.value)
 				}
 
 				// Create context using blackstart.InputsToContext
@@ -621,6 +679,76 @@ func TestSecretValueModule_SetOutputsWrittenValue(t *testing.T) {
 	err = module.Set(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "generated-private-key", ctx.outputs[outputValue])
+}
+
+func TestSecretValueModule_SetRejectsOmittedValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{},
+	}
+	_, err := clientset.CoreV1().Secrets("test-namespace").Create(
+		context.Background(),
+		initialSecret,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewSecretValueModule()
+	inputs := map[string]blackstart.Input{
+		inputSecret: blackstart.NewInputFromValue(&secret{
+			s:  initialSecret,
+			si: clientset.CoreV1().Secrets("test-namespace"),
+		}),
+		inputKey:          blackstart.NewInputFromValue("missing-key"),
+		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserveAny),
+	}
+	ctx := blackstart.InputsToContext(context.Background(), inputs)
+
+	err = module.Set(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be provided when setting a missing key")
+}
+
+func TestSecretValueModule_SetAllowsEmptyStringValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{},
+	}
+	_, err := clientset.CoreV1().Secrets("test-namespace").Create(
+		context.Background(),
+		initialSecret,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewSecretValueModule()
+	inputs := map[string]blackstart.Input{
+		inputSecret: blackstart.NewInputFromValue(&secret{
+			s:  initialSecret,
+			si: clientset.CoreV1().Secrets("test-namespace"),
+		}),
+		inputKey:   blackstart.NewInputFromValue("empty-key"),
+		inputValue: blackstart.NewInputFromValue(""),
+	}
+	ctx := blackstart.InputsToContext(context.Background(), inputs)
+
+	err = module.Set(ctx)
+	require.NoError(t, err)
+	sec, err := clientset.CoreV1().Secrets("test-namespace").Get(
+		context.Background(),
+		"test-secret",
+		metav1.GetOptions{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "", string(sec.Data["empty-key"]))
 }
 
 func TestSecretValueModule(t *testing.T) {

--- a/modules/kubernetes/secret_value_test.go
+++ b/modules/kubernetes/secret_value_test.go
@@ -477,7 +477,7 @@ func TestSecretValueModule_Check(t *testing.T) {
 	}
 }
 
-func TestSecretValueModule_CheckOutputsCurrentValue(t *testing.T) {
+func TestSecretValueModule_CheckOutputsSupportedValueStates(t *testing.T) {
 	clientset := fake.NewClientset()
 	sec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -485,26 +485,63 @@ func TestSecretValueModule_CheckOutputsCurrentValue(t *testing.T) {
 			Namespace: "test-namespace",
 		},
 		Data: map[string][]byte{
-			"private-key": []byte("stored-private-key"),
+			"string-key": []byte("stored-value"),
+			"empty-key":  []byte(""),
 		},
 	}
 
 	module := NewSecretValueModule()
-	inputs := map[string]blackstart.Input{
-		inputSecret: blackstart.NewInputFromValue(&secret{
-			s:  sec,
-			si: clientset.CoreV1().Secrets("test-namespace"),
-		}),
-		inputKey:          blackstart.NewInputFromValue("private-key"),
-		inputValue:        blackstart.NewInputFromValue("new-private-key"),
-		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserve),
+	tests := []struct {
+		name       string
+		key        string
+		wantResult bool
+		wantOutput bool
+		wantValue  string
+	}{
+		{
+			name:       "string_value",
+			key:        "string-key",
+			wantResult: true,
+			wantOutput: true,
+			wantValue:  "stored-value",
+		},
+		{
+			name:       "empty_string_value",
+			key:        "empty-key",
+			wantResult: true,
+			wantOutput: true,
+			wantValue:  "",
+		},
+		{
+			name:       "missing_key",
+			key:        "missing-key",
+			wantResult: false,
+		},
 	}
-	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
 
-	result, err := module.Check(ctx)
-	require.NoError(t, err)
-	assert.True(t, result)
-	assert.Equal(t, "stored-private-key", ctx.outputs[outputValue])
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inputs := map[string]blackstart.Input{
+				inputSecret: blackstart.NewInputFromValue(&secret{
+					s:  sec,
+					si: clientset.CoreV1().Secrets("test-namespace"),
+				}),
+				inputKey: blackstart.NewInputFromValue(test.key),
+			}
+			ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+
+			result, err := module.Check(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantResult, result)
+
+			value, exists := ctx.outputs[outputValue]
+			assert.Equal(t, test.wantOutput, exists)
+			if test.wantOutput {
+				assert.Equal(t, test.wantValue, value)
+				assert.IsType(t, "", value)
+			}
+		})
+	}
 }
 
 func TestSecretValueModule_Set(t *testing.T) {

--- a/modules/kubernetes/secret_value_test.go
+++ b/modules/kubernetes/secret_value_test.go
@@ -26,6 +26,8 @@ func TestSecretValueModule_Info(t *testing.T) {
 	assert.True(t, exists)
 	_, exists = info.Inputs[inputSecret]
 	assert.True(t, exists)
+	_, exists = info.Outputs[outputValue]
+	assert.True(t, exists)
 }
 
 func TestSecretValueModule_Validate(t *testing.T) {
@@ -408,6 +410,36 @@ func TestSecretValueModule_Check(t *testing.T) {
 	}
 }
 
+func TestSecretValueModule_CheckOutputsCurrentValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{
+			"private-key": []byte("stored-private-key"),
+		},
+	}
+
+	module := NewSecretValueModule()
+	inputs := map[string]blackstart.Input{
+		inputSecret: blackstart.NewInputFromValue(&secret{
+			s:  sec,
+			si: clientset.CoreV1().Secrets("test-namespace"),
+		}),
+		inputKey:          blackstart.NewInputFromValue("private-key"),
+		inputValue:        blackstart.NewInputFromValue("new-private-key"),
+		inputUpdatePolicy: blackstart.NewInputFromValue(updatePolicyPreserve),
+	}
+	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+
+	result, err := module.Check(ctx)
+	require.NoError(t, err)
+	assert.True(t, result)
+	assert.Equal(t, "stored-private-key", ctx.outputs[outputValue])
+}
+
 func TestSecretValueModule_Set(t *testing.T) {
 	// Create a fake Kubernetes clientset
 	clientset := fake.NewClientset()
@@ -548,6 +580,38 @@ func TestSecretValueModule_Set(t *testing.T) {
 			},
 		)
 	}
+}
+
+func TestSecretValueModule_SetOutputsWrittenValue(t *testing.T) {
+	clientset := fake.NewClientset()
+	initialSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-secret",
+			Namespace: "test-namespace",
+		},
+		Data: map[string][]byte{},
+	}
+	_, err := clientset.CoreV1().Secrets("test-namespace").Create(
+		context.Background(),
+		initialSecret,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	module := NewSecretValueModule()
+	inputs := map[string]blackstart.Input{
+		inputSecret: blackstart.NewInputFromValue(&secret{
+			s:  initialSecret,
+			si: clientset.CoreV1().Secrets("test-namespace"),
+		}),
+		inputKey:   blackstart.NewInputFromValue("private-key"),
+		inputValue: blackstart.NewInputFromValue("generated-private-key"),
+	}
+	ctx := &capturingModuleContext{ModuleContext: blackstart.InputsToContext(context.Background(), inputs)}
+
+	err = module.Set(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "generated-private-key", ctx.outputs[outputValue])
 }
 
 func TestSecretValueModule(t *testing.T) {

--- a/modules/kubernetes/secret_value_test.go
+++ b/modules/kubernetes/secret_value_test.go
@@ -108,7 +108,7 @@ func TestSecretValueModule_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "missing update policy defaults to overwrite",
+			name: "missing update policy defaults to preserve_any",
 			inputs: map[string]blackstart.Input{
 				inputSecret: blackstart.NewInputFromValue(sec),
 				inputKey:    blackstart.NewInputFromValue("test-key"),
@@ -213,11 +213,20 @@ func TestSecretValueModule_Check(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:           "existing secret existing key correct value - empty policy defaults to overwrite",
+			name:           "existing secret existing key correct value - empty policy defaults to preserve_any",
 			secretName:     "test-secret",
 			namespace:      "test-namespace",
 			key:            "existing-key",
 			value:          "existing-value",
+			updatePolicy:   "",
+			expectedResult: true,
+		},
+		{
+			name:           "existing secret existing key different value - empty policy defaults to preserve_any",
+			secretName:     "test-secret",
+			namespace:      "test-namespace",
+			key:            "existing-key",
+			value:          "different-value",
 			updatePolicy:   "",
 			expectedResult: true,
 		},

--- a/modules/kubernetes/test_context_test.go
+++ b/modules/kubernetes/test_context_test.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import "github.com/pezops/blackstart"
+
+// capturingModuleContext records module outputs while preserving normal context behavior.
+type capturingModuleContext struct {
+	blackstart.ModuleContext
+	outputs map[string]interface{}
+}
+
+// Output records the output value and delegates to the wrapped ModuleContext.
+func (c *capturingModuleContext) Output(key string, value interface{}) error {
+	if c.outputs == nil {
+		c.outputs = map[string]interface{}{}
+	}
+	c.outputs[key] = value
+	return c.ModuleContext.Output(key, value)
+}

--- a/modules/kubernetes/value_input.go
+++ b/modules/kubernetes/value_input.go
@@ -1,0 +1,107 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pezops/blackstart"
+)
+
+// operationUpdatePolicy returns the static update policy for validation when it is known.
+func operationUpdatePolicy(op blackstart.Operation) (string, bool, error) {
+	input, exists := op.Inputs[inputUpdatePolicy]
+	if !exists {
+		return updatePolicyPreserveAny, true, nil
+	}
+	if !input.IsStatic() {
+		return "", false, nil
+	}
+	value, err := blackstart.InputAs[string](input, false)
+	if err != nil {
+		return "", true, fmt.Errorf("input '%s' is invalid: %w", inputUpdatePolicy, err)
+	}
+	updatePolicy := strings.TrimSpace(value)
+	if updatePolicy == "" {
+		updatePolicy = updatePolicyPreserveAny
+	}
+	if _, ok := updatePolicies[updatePolicy]; !ok {
+		return "", true, fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	}
+	return updatePolicy, true, nil
+}
+
+// validateValueInput validates a value input while allowing empty strings.
+func validateValueInput(op blackstart.Operation, updatePolicy string, policyKnown bool) error {
+	input, exists := op.Inputs[inputValue]
+	if !exists {
+		if policyKnown && updatePolicy != updatePolicyPreserveAny {
+			return fmt.Errorf("input '%s' must be provided unless update_policy is '%s'", inputValue, updatePolicyPreserveAny)
+		}
+		return nil
+	}
+	if !input.IsStatic() {
+		return nil
+	}
+	if input.Any() == nil {
+		return fmt.Errorf("input '%s' must not be null", inputValue)
+	}
+	if _, err := blackstart.InputAs[string](input, false); err != nil {
+		return fmt.Errorf("input '%s' is invalid: %w", inputValue, err)
+	}
+	return nil
+}
+
+// contextUpdatePolicy returns the runtime update policy from a module context.
+func contextUpdatePolicy(ctx blackstart.ModuleContext) (string, error) {
+	updatePolicy := updatePolicyPreserveAny
+	updatePolicyInput, err := blackstart.ContextInputAs[string](ctx, inputUpdatePolicy, false)
+	if err == nil {
+		updatePolicy = strings.TrimSpace(updatePolicyInput)
+	}
+	if updatePolicy == "" {
+		updatePolicy = updatePolicyPreserveAny
+	}
+	if _, ok := updatePolicies[updatePolicy]; !ok {
+		return "", fmt.Errorf("input '%s' has invalid value '%s'", inputUpdatePolicy, updatePolicy)
+	}
+	return updatePolicy, nil
+}
+
+// contextOptionalValue returns a possibly omitted value input while allowing empty strings.
+func contextOptionalValue(ctx blackstart.ModuleContext) (string, bool, error) {
+	input, err := ctx.Input(inputValue)
+	if err != nil {
+		if errors.Is(err, blackstart.ErrInputDoesNotExist) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if input.Any() == nil {
+		return "", true, fmt.Errorf("input '%s' must not be null", inputValue)
+	}
+	value, err := blackstart.InputAs[string](input, false)
+	if err != nil {
+		return "", true, fmt.Errorf("input '%s' is invalid: %w", inputValue, err)
+	}
+	return value, true, nil
+}
+
+// requireValueInput enforces value presence for policies that need a desired value.
+func requireValueInput(updatePolicy string, hasValue bool) error {
+	if hasValue {
+		return nil
+	}
+	if updatePolicy == updatePolicyPreserveAny {
+		return nil
+	}
+	return fmt.Errorf("input '%s' must be provided unless update_policy is '%s'", inputValue, updatePolicyPreserveAny)
+}
+
+// requireSetValueInput enforces value presence when Set needs to write a key.
+func requireSetValueInput(hasValue bool) error {
+	if hasValue {
+		return nil
+	}
+	return fmt.Errorf("input '%s' must be provided when setting a missing key", inputValue)
+}


### PR DESCRIPTION
This adds support for simply reading an existing Kubernetes ConfigMap or Secret value. For safety, it also adds a breaking change that makes the default update policy be read only.

This is a breaking change because it changes the default values for the ConfigMap and Secret value modules.